### PR TITLE
Release v1.0.0: modernize deps + biooracler parity

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[docs]"
+      - name: Build site
+        run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,35 +22,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        pip install .
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install -e ".[dev,xarray]"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with pytest (unit tests only)
       run: |
-        pytest
+        pytest -m "not integration"
   deploy:
     runs-on: ubuntu-latest
     needs:
       - test
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,45 +1,63 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# Install Python dependencies, lint, and run tests across supported versions.
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python application
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pytest-cov
-        python -m pip install -e .
-        if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
-    - name: Lint with flake8
+        python -m pip install -e ".[dev,xarray]"
+    - name: Lint with ruff
+      run: ruff check pyo_oracle tests
+    - name: Lint with flake8 (syntax errors only)
+      run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Test with coverage (unit tests only)
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with coverage
-      run: |
-        python -m pytest --cov=pyo_oracle --cov-report=html --cov-report=term-missing tests/
+        python -m pytest -m "not integration" \
+          --cov=pyo_oracle --cov-report=html --cov-report=term-missing tests/
     - name: Upload coverage report
+      if: matrix.python-version == '3.12'
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: htmlcov/
+
+  integration:
+    # Tests that hit the live Bio-ORACLE ERDDAP server. Allowed to fail so a
+    # server hiccup doesn't block CI.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[dev,xarray]"
+    - name: Run integration tests
+      run: python -m pytest -m integration tests/

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,10 +46,9 @@ jobs:
         path: htmlcov/
 
   integration:
-    # Tests that hit the live Bio-ORACLE ERDDAP server. Allowed to fail so a
-    # server hiccup doesn't block CI.
+    # Tests that hit the live Bio-ORACLE ERDDAP server. Blocking: a failure here
+    # gates the PR.
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@
 **/.DS_Store
 **/*.ini
 build/
+dist/
 pyo_oracle/data
 .coverage
 coverage.*
 htmlcov/
 .venv/
+.pytest_cache/
+site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-06-02
+
+First stable release. Modernizes dependencies, reaches feature parity with the
+R package [`biooracler`](https://github.com/bio-oracle/biooracler), and adds new
+functionality.
+
+### Added
+
+- **`info_layer(dataset_id)`** — inspect a layer's dimension ranges (time,
+  latitude, longitude, depth) and its variables with units and long names
+  (parity with `biooracler::info_layer`).
+- **`load_layer(dataset_id, ...)`** — load a layer directly into memory as a
+  `pandas.DataFrame` (default) or `xarray.Dataset` (`fmt="xarray"`).
+- **`build_constraints(...)`** — build griddap constraints from friendly
+  `(min, max)` bounds and strides, with optional validation against the
+  dataset's real ranges.
+- **`variables=`** argument on `download_layers` to download a subset of
+  variables.
+- Optional dependency extras: `xarray`, `docs`, `dev`.
+- MkDocs Material documentation site (quickstart, tutorials, API reference) with
+  a GitHub Pages deploy workflow.
+- `respx` and `ruff` to the dev toolchain; `integration` pytest marker to
+  separate live-server tests from offline unit tests.
+- `CLAUDE.md` contributor guide and this changelog.
+
+### Changed
+
+- Declared explicit dependencies (`erddapy>=2.2`, `pandas>=2.0`, `httpx>=0.27`)
+  and raised the Python floor to `>=3.9`.
+- Refactored griddap server construction into a single shared
+  `_build_griddap_server` helper used by downloads, in-memory loading, and
+  metadata lookups.
+- CI now tests a Python 3.9–3.13 matrix, lints with ruff, and runs offline unit
+  tests by default with a separate (non-blocking) integration job.
+
+### Fixed
+
+- Replaced unsafe `eval()` parsing of the `skip_confirmation` config value with a
+  safe boolean coercion (`_as_bool`), which also handles strings like `"false"`.
+- Hardened handling of erddapy's private `_constraints_original` attribute.
+
+## [0.2.0]
+
+- Previous release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+## What this is
+
+`pyo_oracle` is the Python client for the **Bio-ORACLE** ERDDAP server
+(<https://erddap.bio-oracle.org/erddap/>). It is the Python counterpart of the R
+package [`biooracler`](https://github.com/bio-oracle/biooracler) and is built on
+top of [`erddapy`](https://github.com/ioos/erddapy).
+
+## Layout
+
+- `pyo_oracle/__init__.py` — public namespace; re-exports the API.
+- `pyo_oracle/main.py` — public functions: `list_layers`, `info_layer`,
+  `load_layer`, `download_layers`, `list_local_data`.
+- `pyo_oracle/utils.py` — internals: `_build_griddap_server` (the single shared
+  griddap setup path), `_layer_info`, `_layer_dataframe`, `build_constraints`,
+  `_as_bool`, download helpers.
+- `pyo_oracle/_config.py` — configparser-based config (data dir, server URL,
+  `skip_confirmation`). `config.ini` is generated and git-ignored.
+- `tests/` — `test_utils.py` (offline), `test_main.py` (mostly live), `test_config.py`.
+- `docs/` + `mkdocs.yml` — MkDocs Material site (mkdocstrings API ref).
+
+## Public API parity with `biooracler`
+
+`list_layers`, `info_layer`, `download_layers` mirror the R package. Python adds
+`load_layer` (in-memory pandas/xarray) and `build_constraints` (friendly
+subsetting helper).
+
+## Dev environment
+
+All development happens in the conda env named **`pyo_oracle`**:
+
+```bash
+conda env create -n pyo_oracle -f environment-dev.yaml   # or `mamba`
+conda activate pyo_oracle
+pip install -e ".[dev,xarray,docs]"
+```
+
+## Tests
+
+Two kinds, separated by the `integration` marker:
+
+```bash
+pytest -m "not integration"   # offline unit tests (fast, used in CI by default)
+pytest                        # full suite incl. tests that hit the live server
+pytest -m integration         # only the live-server tests
+```
+
+The exit goal for changes is a **fully green `pytest`** in the `pyo_oracle` env.
+
+## Lint & docs
+
+```bash
+ruff check pyo_oracle tests
+mkdocs serve          # live preview
+mkdocs build --strict # must pass (CI deploys to GitHub Pages)
+```
+
+## Release flow
+
+1. Bump `version` in `pyproject.toml` and update `CHANGELOG.md`.
+2. Ensure `pytest`, `ruff`, and `mkdocs build --strict` pass.
+3. `python -m build` and inspect the artifacts.
+4. Push a tag — `.github/workflows/pypi-publish.yml` builds and publishes to PyPI
+   (package name `pyo-oracle`).
+
+## Gotchas
+
+- **erddapy private API**: `_build_griddap_server` relies on
+  `ERDDAP._constraints_original`. It is guarded with `getattr`/`hasattr` but
+  watch this if bumping erddapy (verified against erddapy 3.2.x).
+- Requires `erddapy>=2.2`, `pandas>=2.0`, Python `>=3.9`. xarray loading needs
+  the optional `xarray` extra (`xarray` + `netCDF4`).
+- `download_layers` with no constraints downloads the entire global layer and
+  prompts for confirmation unless `skip_confirmation=True`.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,82 @@
 # pyo_oracle
-## Python interface for the Bio-ORACLE ERDDAP server
 
-### Quick start
+**Python client for the [Bio-ORACLE](https://bio-oracle.org/) ERDDAP server.**
 
-```python
-import pyo_oracle
+Discover, inspect, subset, download, and load Bio-ORACLE marine environmental
+layers (temperature, salinity, nutrients, sea ice, and more) from Python.
+`pyo_oracle` is the Python counterpart of the R package
+[`biooracler`](https://github.com/bio-oracle/biooracler) and is built on
+[`erddapy`](https://github.com/ioos/erddapy).
 
-# List available layers in the Bio-ORACLE server
-pyo_oracle.list_layers()
+📖 **Documentation:** <https://bio-oracle.github.io/pyo_oracle/>
 
-# Define constraints and download a layer (the full layer is a large file)
-constraints = {
-    "time>=": "2000-01-01T00:00:00Z",
-    "time<=": "2010-01-01T12:00:00Z",
-    "time_step": 100,
-    "latitude>=": 0,
-    "latitude<=": 10,
-    "latitude_step": 100,
-    "longitude>=": 0,
-    "longitude<=": 10,
-    "longitude_step": 1
-}
-pyo_oracle.download_layers("thetao_baseline_2000_2019_depthsurf", constraints=constraints)
-
-# See local data
-pyo_oracle.list_local_data()
-```
-
-### Installation
+## Installation
 
 ```bash
+# With pip
+pip install pyo-oracle
+
+# Load layers as xarray (optional extra)
+pip install "pyo-oracle[xarray]"
+
 # With conda
 conda create -n pyo_oracle conda-forge::pyo-oracle
-
-# or with pip
-pip install pyo-oracle
 ```
 
-Please open an issue if you experience any problems. More documentation coming soon!
+## Quick start
+
+```python
+import pyo_oracle as pyo
+
+# 1. List available layers (filter by search term, variable, scenario, depth, ...)
+pyo.list_layers(search="Temperature")
+
+# 2. Inspect a layer: dimension ranges + variables and units
+pyo.info_layer("thetao_baseline_2000_2019_depthsurf")
+
+# 3. Build constraints from friendly bounds (no hand-written dicts)
+constraints = pyo.build_constraints(
+    "thetao_baseline_2000_2019_depthsurf",
+    time=("2000-01-01T00:00:00Z", "2010-01-01T00:00:00Z"),
+    latitude=(0, 10),
+    longitude=(0, 10),
+)
+
+# 4a. Load directly into memory (pandas or xarray)
+df = pyo.load_layer(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    variables=["thetao_mean"],
+)
+ds = pyo.load_layer(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    fmt="xarray",
+)
+
+# 4b. Or download to a file (NetCDF by default)
+pyo.download_layers(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    variables=["thetao_mean"],
+)
+
+# 5. See local data
+pyo.list_local_data()
+```
+
+## Key functions
+
+| Function | Purpose |
+|----------|---------|
+| `list_layers` | List/filter available layers |
+| `info_layer` | Inspect a layer's dimensions and variables |
+| `build_constraints` | Build griddap constraints from `(min, max)` bounds + strides |
+| `load_layer` | Load a layer into memory (`pandas` or `xarray`) |
+| `download_layers` | Download a layer (NetCDF/CSV), optionally a variable subset |
+| `list_local_data` | List downloaded files |
+
+## Contributing
+
+See [`CLAUDE.md`](CLAUDE.md) for the dev setup, testing, and release flow.
+Please open an issue if you experience any problems.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,32 @@
+# API reference
+
+All public functions are available directly from the top-level `pyo_oracle`
+namespace, e.g. `pyo_oracle.list_layers(...)`.
+
+## Discovery
+
+::: pyo_oracle.list_layers
+
+::: pyo_oracle.info_layer
+
+## Subsetting
+
+::: pyo_oracle.build_constraints
+
+## Data access
+
+::: pyo_oracle.load_layer
+
+::: pyo_oracle.download_layers
+
+::: pyo_oracle.list_local_data
+
+## Configuration
+
+::: pyo_oracle.create_config
+
+::: pyo_oracle.get_config_path
+
+::: pyo_oracle.print_config_values
+
+::: pyo_oracle.update_setting

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+# pyo_oracle
+
+**Python client for the [Bio-ORACLE](https://bio-oracle.org/) ERDDAP server.**
+
+`pyo_oracle` lets you discover, inspect, subset, download, and load Bio-ORACLE
+marine environmental layers (temperature, salinity, nutrients, sea ice, and
+more) straight from Python. It is the Python counterpart of the R package
+[`biooracler`](https://github.com/bio-oracle/biooracler) and is built on top of
+[`erddapy`](https://github.com/ioos/erddapy).
+
+## Features
+
+- **List & filter** layers by free-text search, variable, SSP scenario, time period, and depth.
+- **Inspect** a layer's dimension ranges and variables with [`info_layer`][pyo_oracle.info_layer].
+- **Subset** easily with [`build_constraints`][pyo_oracle.build_constraints] — no hand-written constraint dicts.
+- **Download** to NetCDF/CSV files, optionally restricting to a subset of variables.
+- **Load into memory** as a `pandas.DataFrame` or `xarray.Dataset` with [`load_layer`][pyo_oracle.load_layer].
+
+## Installation
+
+```bash
+# With pip
+pip install pyo-oracle
+
+# Load layers as xarray (optional extra)
+pip install "pyo-oracle[xarray]"
+
+# With conda
+conda create -n pyo_oracle conda-forge::pyo-oracle
+```
+
+## Quick example
+
+```python
+import pyo_oracle as pyo
+
+# Discover layers
+pyo.list_layers(search="Temperature")
+
+# Inspect one
+pyo.info_layer("thetao_baseline_2000_2019_depthsurf")
+
+# Build constraints and load into memory
+constraints = pyo.build_constraints(
+    "thetao_baseline_2000_2019_depthsurf",
+    latitude=(0, 10),
+    longitude=(0, 10),
+)
+df = pyo.load_layer(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    variables=["thetao_mean"],
+)
+```
+
+See the [Quickstart](quickstart.md) and [Tutorials](tutorials/listing-and-filtering.md) to go further.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart
+
+This page walks through the full workflow: **list → inspect → subset → load/download → manage local data.**
+
+## 1. List available layers
+
+```python
+import pyo_oracle as pyo
+
+# All layers as a DataFrame
+layers = pyo.list_layers()
+
+# Free-text search
+pyo.list_layers(search="Temperature")
+
+# Filter by variable, scenario, time period, depth
+pyo.list_layers(variables=["thetao"], time_period="present", depth="surf")
+
+# Just the dataset IDs
+ids = pyo.list_layers(variables="thetao", dataframe=False)
+```
+
+## 2. Inspect a layer
+
+```python
+pyo.info_layer("thetao_baseline_2000_2019_depthsurf")
+```
+
+This prints the dimension ranges (time, latitude, longitude, and depth when
+present) and the available variables with their units. It also returns a
+dictionary you can use programmatically.
+
+## 3. Build constraints
+
+Instead of hand-writing the griddap constraint dictionary, use
+[`build_constraints`][pyo_oracle.build_constraints]:
+
+```python
+constraints = pyo.build_constraints(
+    "thetao_baseline_2000_2019_depthsurf",
+    time=("2000-01-01T00:00:00Z", "2010-01-01T00:00:00Z"),
+    latitude=(0, 10),
+    longitude=(0, 10),
+    latitude_step=2,   # take every 2nd grid cell along latitude
+)
+```
+
+When the `dataset_id` is supplied, requested bounds are checked against the
+dataset's real ranges and a warning is emitted if they fall outside.
+
+## 4. Load into memory or download to disk
+
+```python
+# In-memory DataFrame
+df = pyo.load_layer(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    variables=["thetao_mean"],
+)
+
+# In-memory xarray.Dataset (requires the `xarray` extra)
+ds = pyo.load_layer(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    fmt="xarray",
+)
+
+# Download to a NetCDF file
+pyo.download_layers(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    variables=["thetao_mean"],
+)
+```
+
+## 5. Manage local data
+
+```python
+pyo.list_local_data()
+```
+
+## Configuration
+
+`pyo_oracle` stores a small config (data directory, ERDDAP server URL,
+confirmation prompts):
+
+```python
+pyo.print_config_values()
+pyo.update_setting("skip_confirmation", "True")
+```

--- a/docs/tutorials/downloading-and-subsetting.md
+++ b/docs/tutorials/downloading-and-subsetting.md
@@ -1,0 +1,83 @@
+# Downloading and subsetting
+
+Bio-ORACLE layers are global and can be several gigabytes. Subsetting before
+downloading keeps requests fast and small.
+
+## Inspect first
+
+Always check a layer's real ranges before subsetting:
+
+```python
+import pyo_oracle as pyo
+
+info = pyo.info_layer("thetao_baseline_2000_2019_depthsurf")
+info["dimensions"]   # {'time': (...), 'latitude': (...), 'longitude': (...)}
+info["variables"]    # {'thetao_mean': {'units': 'degree_C', 'long_name': ...}, ...}
+```
+
+## Build constraints
+
+[`build_constraints`][pyo_oracle.build_constraints] turns friendly `(min, max)`
+bounds and strides into the griddap dictionary ERDDAP expects:
+
+```python
+constraints = pyo.build_constraints(
+    "thetao_baseline_2000_2019_depthsurf",
+    time=("2000-01-01T00:00:00Z", "2010-01-01T00:00:00Z"),
+    latitude=(-40, -10),
+    longitude=(110, 155),
+    latitude_step=1,
+    longitude_step=1,
+)
+```
+
+The equivalent hand-written dictionary (still accepted) looks like:
+
+```python
+constraints = {
+    "time>=": "2000-01-01T00:00:00Z",
+    "time<=": "2010-01-01T00:00:00Z",
+    "time_step": 1,
+    "latitude>=": -40,
+    "latitude<=": -10,
+    "latitude_step": 1,
+    "longitude>=": 110,
+    "longitude<=": 155,
+    "longitude_step": 1,
+}
+```
+
+### Strides
+
+`*_step` arguments take every *n*-th grid cell along a dimension — a quick way
+to downsample a large region.
+
+## Restrict variables
+
+Most layers ship several statistics (`_mean`, `_min`, `_max`, `_range`, ...).
+Download only what you need:
+
+```python
+pyo.download_layers(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    variables=["thetao_mean"],
+    response="nc",          # or "csv"
+)
+```
+
+## Where files go
+
+Downloads land in the configured data directory (see
+[`print_config_values`][pyo_oracle.print_config_values]) unless you pass
+`output_directory=`. A `.log` file recording the constraints is written next to
+each download.
+
+```python
+pyo.list_local_data()
+```
+
+!!! warning
+    Calling `download_layers` without constraints downloads the **entire global
+    layer**. `pyo_oracle` will ask for confirmation first; pass
+    `skip_confirmation=True` to bypass the prompt in scripts.

--- a/docs/tutorials/listing-and-filtering.md
+++ b/docs/tutorials/listing-and-filtering.md
@@ -1,0 +1,56 @@
+# Listing and filtering layers
+
+Bio-ORACLE exposes hundreds of layers. [`list_layers`][pyo_oracle.list_layers]
+helps you find the ones you need.
+
+## All layers
+
+```python
+import pyo_oracle as pyo
+
+df = pyo.list_layers()
+df.head()
+```
+
+By default a `pandas.DataFrame` is returned. Pass `dataframe=False` to get a
+plain list of dataset IDs instead.
+
+## Free-text search
+
+```python
+pyo.list_layers(search="Oxygen")
+pyo.list_layers(search=["Temperature", "Salinity"])  # OR across terms
+```
+
+The search matches against the dataset ID, title, long name and standard name.
+
+## Structured filters
+
+You can combine any of the following filters:
+
+| Argument | Valid values |
+|----------|--------------|
+| `variables` | `chl, clt, dfe, mlotst, no3, o2, ph, phyc, po4, si, siconc, sithick, so, swd, sws, tas, terrain, thetao` |
+| `ssp` | `ssp119, ssp126, ssp245, ssp370, ssp460, ssp585, baseline` |
+| `time_period` | `present`, `future` |
+| `depth` | `min, mean, max, surf` |
+
+```python
+# Future projections of phosphate under two SSP scenarios, as IDs
+pyo.list_layers(
+    variables="po4",
+    ssp=["ssp119", "ssp126"],
+    time_period="future",
+    dataframe=False,
+)
+```
+
+## Simplify the output
+
+```python
+pyo.list_layers(variables="thetao", simplify=True)  # only datasetID + title
+```
+
+!!! tip
+    Results are cached, so repeated calls with the same filters (in any order)
+    are instant and return the same object.

--- a/docs/tutorials/xarray-and-plotting.md
+++ b/docs/tutorials/xarray-and-plotting.md
@@ -1,0 +1,64 @@
+# Working with xarray
+
+For gridded analysis and plotting, load layers directly into an
+`xarray.Dataset` with [`load_layer`][pyo_oracle.load_layer]. This requires the
+optional `xarray` extra:
+
+```bash
+pip install "pyo-oracle[xarray]"
+```
+
+## Load a subset as xarray
+
+```python
+import pyo_oracle as pyo
+
+ds_id = "thetao_baseline_2000_2019_depthsurf"
+constraints = pyo.build_constraints(
+    ds_id,
+    latitude=(-60, 60),
+    longitude=(-180, 180),
+    latitude_step=4,
+    longitude_step=4,
+)
+
+ds = pyo.load_layer(ds_id, constraints=constraints, variables=["thetao_mean"], fmt="xarray")
+ds
+```
+
+`ds` is a standard `xarray.Dataset` with `time`, `latitude` and `longitude`
+coordinates, so the whole xarray ecosystem is available.
+
+## Quick map
+
+```python
+import matplotlib.pyplot as plt
+
+ds["thetao_mean"].isel(time=0).plot(figsize=(10, 5), cmap="thermal")
+plt.title("Mean sea surface temperature (baseline)")
+plt.show()
+```
+
+For publication-quality maps with coastlines and projections, combine with
+[`cartopy`](https://scitools.org.uk/cartopy/):
+
+```python
+import cartopy.crs as ccrs
+
+ax = plt.axes(projection=ccrs.Robinson())
+ds["thetao_mean"].isel(time=0).plot(
+    ax=ax, transform=ccrs.PlateCarree(), cmap="thermal"
+)
+ax.coastlines()
+plt.show()
+```
+
+## pandas instead
+
+If you prefer tabular data (e.g. to join with occurrence records for species
+distribution modelling), use the default `fmt="pandas"`:
+
+```python
+df = pyo.load_layer(ds_id, constraints=constraints, variables=["thetao_mean"])
+df.head()
+```

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -1,9 +1,21 @@
-name: pyo-oracle-dev
+name: pyo_oracle
 channels:
   - conda-forge
 dependencies:
+  - python>=3.9
   - erddapy
+  - pandas>=2.0
   - httpx
+  - xarray
+  - netCDF4
   - ipython
   - pytest
   - pytest-cov
+  - respx
+  - flake8
+  - ruff
+  - pip
+  - pip:
+      - mkdocs-material
+      - "mkdocstrings[python]"
+      - mkdocs-jupyter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,56 @@
+site_name: pyo_oracle
+site_description: Python client for the Bio-ORACLE ERDDAP server
+site_url: https://bio-oracle.github.io/pyo_oracle/
+repo_url: https://github.com/bio-oracle/pyo_oracle
+repo_name: bio-oracle/pyo_oracle
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            heading_level: 2
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.details
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Tutorials:
+      - Listing and filtering: tutorials/listing-and-filtering.md
+      - Downloading and subsetting: tutorials/downloading-and-subsetting.md
+      - Working with xarray: tutorials/xarray-and-plotting.md
+  - API reference: api.md

--- a/pyo_oracle/__init__.py
+++ b/pyo_oracle/__init__.py
@@ -1,4 +1,11 @@
-from .main import download_layers, list_layers, list_local_data
+from .main import (
+    build_constraints,
+    download_layers,
+    info_layer,
+    list_layers,
+    list_local_data,
+    load_layer,
+)
 from . import _config as config_module
 
 # Re-export helpers so users can call pyo.create_config(), etc.
@@ -13,6 +20,9 @@ __all__ = [
     "download_layers",
     "list_layers",
     "list_local_data",
+    "info_layer",
+    "load_layer",
+    "build_constraints",
     "config",
     "create_config",
     "get_config_path",

--- a/pyo_oracle/_config.py
+++ b/pyo_oracle/_config.py
@@ -47,9 +47,9 @@ def _get_default_config() -> configparser.ConfigParser:
             print("Config file doesn't exist, creating it.")
             create_config()
             return _get_default_config()
-        except Exception as e:
+        except Exception:
             print(
-                f"Error: could not load or create configuration file. Loading default values."
+                "Error: could not load or create configuration file. Loading default values."
             )
             config = configparser.ConfigParser()
             config["DEFAULT"] = _default_config

--- a/pyo_oracle/main.py
+++ b/pyo_oracle/main.py
@@ -23,14 +23,27 @@ import pandas as pd
 
 from pyo_oracle._config import config
 from pyo_oracle.utils import (
+    _as_bool,
+    _build_griddap_server,
     _download_layer,
     _ensure_hashable,
     _layer_dataframe,
+    _layer_info,
     _validate_argument,
+    build_constraints,
     confirm,
     convert_bytes,
     verbose_print,
 )
+
+__all__ = [
+    "download_layers",
+    "list_layers",
+    "list_local_data",
+    "info_layer",
+    "load_layer",
+    "build_constraints",
+]
 
 # Literal typing for type checking and validation (using _validate_argument)
 Variable = Literal[
@@ -63,6 +76,7 @@ def download_layers(
     output_directory: Optional[Union[str, Path]] = None,
     response: str = "nc",
     constraints: Optional[Dict[str, Any]] = None,
+    variables: Optional[Iterable[str]] = None,
     skip_confirmation: Optional[bool] = None,
     verbose: bool = True,
     log: bool = True,
@@ -78,7 +92,8 @@ def download_layers(
         dataset_ids (str or list): Dataset ID(s) to download. A single dataset ID or a list of IDs.
         output_directory (str or Path, optional): Directory where downloaded files will be saved. If not provided, the default directory will be used.
         response (str, optional): Format of the response to download. Default is 'nc'.
-        constraints (dict, optional): Constraints to apply to the downloaded data.
+        constraints (dict, optional): Constraints to apply to the downloaded data. See ``build_constraints`` for a convenient way to build this dictionary.
+        variables (list, optional): Subset of variables to download. If not provided, all variables in the dataset are downloaded.
         skip_confirmation (bool, optional): If True, confirmation prompts will be skipped. If None, the value from the configuration will be used.
         verbose (bool, optional): If True, detailed information will be printed during the download process.
         log (bool, optional): If True, a log of the download will be created.
@@ -97,14 +112,20 @@ def download_layers(
         # Download a single dataset with default settings
         download_layers(dataset_ids="dataset123")
 
-        # Download multiple datasets with custom settings
-        download_layers(dataset_ids=["dataset456", "dataset789"], output_directory="/path/to/output", response="csv", verbose=False)
+        # Download multiple datasets with custom settings, restricting to two variables
+        download_layers(
+            dataset_ids=["dataset456", "dataset789"],
+            output_directory="/path/to/output",
+            response="csv",
+            variables=["thetao_mean"],
+            verbose=False,
+        )
     """
     if isinstance(dataset_ids, str):
         dataset_ids = (dataset_ids,)
 
     if skip_confirmation is None:
-        skip_confirmation = eval(config["skip_confirmation"])
+        skip_confirmation = _as_bool(config["skip_confirmation"])
 
     if not skip_confirmation and not constraints:
         question = "No constraints have been set. This will download the full dataset, which may be a few GBs in size."
@@ -126,6 +147,7 @@ def download_layers(
             log,
             timestamp,
             timeout,
+            variables=variables,
             **httpx_kwargs,
         )
 
@@ -303,7 +325,9 @@ def _list_layers(
         return _dataframe["datasetID"].to_list()
 
 
-def list_local_data(data_directory: Optional[Union[str, Path]] = None, verbose: bool = True):
+def list_local_data(
+    data_directory: Optional[Union[str, Path]] = None, verbose: bool = True
+) -> None:
     """
     Lists datasets that are locally downloaded.
 
@@ -344,3 +368,89 @@ def list_local_data(data_directory: Optional[Union[str, Path]] = None, verbose: 
         dirsize = sum(Path(f).stat().st_size for f in files)
         dirsize = convert_bytes(dirsize)
         verbose_print(f"Size of data directory is {dirsize}.", verbose)
+
+
+def info_layer(dataset_id: str, verbose: bool = True) -> Dict[str, Any]:
+    """
+    Returns metadata about a single layer (dataset).
+
+    Mirrors ``biooracler::info_layer``: reports the dimension ranges
+    (time, latitude, longitude, and depth when present) and the available
+    variables together with their units and long names.
+
+    Args:
+        dataset_id (str): The dataset ID to inspect, e.g. "thetao_baseline_2000_2019_depthsurf".
+        verbose (bool): If True (default), pretty-print the metadata as well as returning it.
+
+    Returns:
+        dict: A dictionary with keys ``dataset_id``, ``dimensions``
+        (mapping dim name -> (min, max)), ``variables`` (mapping variable name ->
+        {"units", "long_name"}) and ``griddap_constraints`` (the full-range
+        constraints dict accepted by ``download_layers`` / ``load_layer``).
+
+    Example:
+        info = info_layer("thetao_baseline_2000_2019_depthsurf")
+    """
+    info = _layer_info(dataset_id)
+
+    if verbose:
+        print(f"Dataset ID: {info['dataset_id']}\n")
+        print("Dimensions:")
+        for dim, (lo, hi) in info["dimensions"].items():
+            print(f"\t{dim}: {lo} to {hi}")
+        print("\nVariables:")
+        for var, meta in info["variables"].items():
+            units = meta.get("units")
+            long_name = meta.get("long_name")
+            label = long_name or var
+            unit_str = f" [{units}]" if units else ""
+            print(f"\t{var}: {label}{unit_str}")
+        print()
+
+    return info
+
+
+def load_layer(
+    dataset_id: str,
+    constraints: Optional[Dict[str, Any]] = None,
+    variables: Optional[Iterable[str]] = None,
+    fmt: Literal["pandas", "xarray"] = "pandas",
+    verbose: bool = False,
+) -> Any:
+    """
+    Loads a layer directly into memory instead of writing it to a file.
+
+    This is the in-memory counterpart of ``download_layers`` and mirrors
+    ``biooracler::download_layers`` returning data into the session.
+
+    Args:
+        dataset_id (str): The dataset ID to load.
+        constraints (dict, optional): Constraints to apply. See ``build_constraints``.
+        variables (list, optional): Subset of variables to load. If None, all are loaded.
+        fmt (str): "pandas" (default) returns a ``pandas.DataFrame``; "xarray" returns
+            an ``xarray.Dataset`` (requires the optional ``xarray`` extra:
+            ``pip install pyo_oracle[xarray]``).
+        verbose (bool): If True, print selection details.
+
+    Returns:
+        pandas.DataFrame or xarray.Dataset: The requested data.
+
+    Example:
+        df = load_layer("thetao_baseline_2000_2019_depthsurf", constraints=constraints)
+        ds = load_layer("thetao_baseline_2000_2019_depthsurf", fmt="xarray")
+    """
+    if fmt not in ("pandas", "xarray"):
+        raise ValueError(f"Unsupported fmt '{fmt}'. Use 'pandas' or 'xarray'.")
+
+    server = _build_griddap_server(dataset_id, variables, constraints, verbose)
+
+    if fmt == "pandas":
+        return server.to_pandas()
+
+    try:
+        return server.to_xarray()
+    except ImportError as exc:  # pragma: no cover - exercised via install state
+        raise ImportError(
+            "Loading layers as xarray requires the optional dependencies. "
+            "Install them with: pip install pyo_oracle[xarray]"
+        ) from exc

--- a/pyo_oracle/utils.py
+++ b/pyo_oracle/utils.py
@@ -3,6 +3,7 @@ Utilities and private methods that are used internally.
 """
 
 import logging
+import warnings
 from copy import deepcopy
 from datetime import datetime
 from functools import lru_cache
@@ -102,8 +103,16 @@ def _download_file_from_url(url: str, local_path: Path, **httpx_kwargs) -> Path:
 
 
 # Small helpers
-verbose_print = lambda message, verbose: print(message) if verbose else None
-info_logger = lambda msg, log: logging.info(msg) if log else None
+def verbose_print(message: Any, verbose: bool) -> None:
+    """Print ``message`` only when ``verbose`` is True."""
+    if verbose:
+        print(message)
+
+
+def info_logger(msg: Any, log: bool) -> None:
+    """Log ``msg`` at INFO level only when ``log`` is True."""
+    if log:
+        logging.info(msg)
 
 
 def confirm(msg: str, cancel_msg: str = "Download cancelled.") -> bool:
@@ -129,6 +138,80 @@ def confirm(msg: str, cancel_msg: str = "Download cancelled.") -> bool:
         return False
 
 
+def _as_bool(value: Any) -> bool:
+    """
+    Safely coerce a config/CLI value to a boolean.
+
+    Replaces the previous ``eval(...)`` based parsing, which was unsafe and
+    failed on values such as the string ``"false"``.
+
+    Args:
+        value: A value that may be a bool, or a string such as "True"/"false"/"1".
+
+    Returns:
+        bool: The parsed boolean value.
+    """
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"true", "1", "yes", "y", "on"}
+
+
+def _build_griddap_server(
+    dataset_id: str,
+    variables: Optional[Container[str]] = None,
+    constraints: Optional[Dict[str, Any]] = None,
+    verbose: bool = False,
+):
+    """
+    Build and configure an erddapy ``ERDDAP`` server for a griddap dataset.
+
+    This is the single, shared code path used by ``_get_griddap_dataset_url``,
+    ``load_layer`` and ``_layer_info`` so that the (somewhat fragile) handling
+    of erddapy's private ``_constraints_original`` lives in exactly one place.
+
+    Args:
+        dataset_id (str): The ID of the dataset.
+        variables (container of str, optional): Variable names to select. If None, all are kept.
+        constraints (dict[str, Any], optional): Constraints to apply on top of the dataset defaults.
+        verbose (bool, optional): If True, print selection details.
+
+    Returns:
+        erddapy.ERDDAP: A configured server instance with ``protocol='griddap'``.
+    """
+    server = deepcopy(default_server)
+    server.dataset_id = dataset_id
+    server.protocol = "griddap"
+    server.griddap_initialize()
+
+    verbose_print(f"Selected '{dataset_id}' dataset.", verbose)
+    verbose_print(f"Dataset info available at: {server.get_info_url()}", verbose)
+
+    # Setting constraints that match. erddapy exposes ``_constraints_original``;
+    # we merge user constraints on top of the dataset's full-range defaults.
+    if constraints:
+        original = getattr(server, "_constraints_original", None) or dict(
+            server.constraints
+        )
+        merged = {**original, **constraints}
+        for k, v in merged.items():
+            if k in server.constraints.keys():
+                server.constraints[k] = v
+                if hasattr(server, "_constraints_original"):
+                    server._constraints_original[k] = v
+
+    # The same for variables
+    if variables:
+        server.variables = [v for v in server.variables if v in variables]
+    verbose_print(
+        f"Selected {len(server.variables)} variables: {server.variables}.", verbose
+    )
+    return server
+
+
 def _get_griddap_dataset_url(
     dataset_id: str,
     variables: Optional[Container[str]] = None,
@@ -149,36 +232,147 @@ def _get_griddap_dataset_url(
     Returns:
         str: The URL for downloading the dataset.
 
-    Note:
-        This function prepares the necessary information to generate a Griddap download URL based on the provided parameters.
-
     Example:
         url = _get_griddap_dataset_url("dataset123", variables=["temperature", "salinity"], constraints={"time": "2023-01-01"}, response="csv", verbose=True)
     """
-    server = deepcopy(default_server)
-    server.dataset_id = dataset_id
-    server.protocol = "griddap"
-    server.griddap_initialize()
+    server = _build_griddap_server(dataset_id, variables, constraints, verbose)
+    return server.get_download_url(response=response)
 
-    verbose_print(f"Selected '{dataset_id}' dataset.", verbose)
-    verbose_print(f"Dataset info available at: {server.get_info_url()}", verbose)
 
-    # Setting constraints that match
-    if constraints:
-        constraints = {**server._constraints_original, **constraints}
-        for k, v in constraints.items():
-            if k in server.constraints.keys():
-                server.constraints[k] = v
-                server._constraints_original[k] = v
+# Dimensions handled by ``build_constraints`` and reported by ``_layer_info``.
+_DIMENSIONS = ("time", "latitude", "longitude", "depth")
 
-    # The same for variables
-    if variables:
-        server.variables = [v for v in server.variables if v in variables]
-    verbose_print(
-        f"Selected {len(server.variables)} variables: {server.variables}.", verbose
-    )
-    url = server.get_download_url(response=response)
-    return url
+
+@lru_cache(maxsize=32)
+def _layer_info(dataset_id: str) -> Dict[str, Any]:
+    """
+    Fetch structured metadata for a single griddap layer.
+
+    Args:
+        dataset_id (str): The dataset ID.
+
+    Returns:
+        dict: A dictionary with keys:
+            - ``dataset_id``
+            - ``dimensions``: mapping dim name -> (min, max) for time/latitude/longitude/depth
+            - ``variables``: mapping variable name -> {"units", "long_name"}
+            - ``griddap_constraints``: the dataset's full-range constraints dict
+    """
+    server = _build_griddap_server(dataset_id)
+
+    dimensions: Dict[str, Tuple[Any, Any]] = {}
+    for dim in _DIMENSIONS:
+        lo = server.constraints.get(f"{dim}>=")
+        hi = server.constraints.get(f"{dim}<=")
+        if lo is not None or hi is not None:
+            dimensions[dim] = (lo, hi)
+
+    variables: Dict[str, Dict[str, Optional[str]]] = {}
+    try:
+        info = pd.read_csv(server.get_info_url(response="csv"))
+        attrs = info[info["Row Type"] == "attribute"]
+        for var in server.variables:
+            sub = attrs[attrs["Variable Name"] == var]
+            units = sub.loc[sub["Attribute Name"] == "units", "Value"]
+            long_name = sub.loc[sub["Attribute Name"] == "long_name", "Value"]
+            variables[var] = {
+                "units": units.iloc[0] if not units.empty else None,
+                "long_name": long_name.iloc[0] if not long_name.empty else None,
+            }
+    except Exception:
+        # Metadata is best-effort; fall back to bare variable names.
+        for var in server.variables:
+            variables[var] = {"units": None, "long_name": None}
+
+    return {
+        "dataset_id": dataset_id,
+        "dimensions": dimensions,
+        "variables": variables,
+        "griddap_constraints": dict(server.constraints),
+    }
+
+
+def build_constraints(
+    dataset_id: Optional[str] = None,
+    time: Optional[Tuple[Any, Any]] = None,
+    latitude: Optional[Tuple[float, float]] = None,
+    longitude: Optional[Tuple[float, float]] = None,
+    depth: Optional[Tuple[float, float]] = None,
+    time_step: int = 1,
+    latitude_step: int = 1,
+    longitude_step: int = 1,
+    depth_step: int = 1,
+    validate: bool = True,
+) -> Dict[str, Any]:
+    """
+    Build a griddap constraints dictionary from human-friendly bounds.
+
+    Instead of hand-writing the ``{"time>=": ..., "time<=": ..., "time_step": ...}``
+    dictionary, pass ``(min, max)`` tuples per dimension and optional strides.
+
+    Args:
+        dataset_id (str, optional): If given and ``validate`` is True, bounds are
+            checked against the dataset's real dimension ranges and a warning is
+            emitted (not an error) when they fall outside.
+        time (tuple, optional): ``(start, end)`` as ISO strings, e.g. ("2000-01-01T00:00:00Z", "2010-01-01T00:00:00Z").
+        latitude (tuple, optional): ``(min, max)`` latitude in degrees.
+        longitude (tuple, optional): ``(min, max)`` longitude in degrees.
+        depth (tuple, optional): ``(min, max)`` depth.
+        time_step (int): Stride along time. Default 1.
+        latitude_step (int): Stride along latitude. Default 1.
+        longitude_step (int): Stride along longitude. Default 1.
+        depth_step (int): Stride along depth. Default 1.
+        validate (bool): If True and ``dataset_id`` is given, validate bounds.
+
+    Returns:
+        dict: A constraints dictionary suitable for ``download_layers`` / ``load_layer``.
+
+    Example:
+        constraints = build_constraints(
+            time=("2000-01-01T00:00:00Z", "2010-01-01T00:00:00Z"),
+            latitude=(0, 10),
+            longitude=(0, 10),
+        )
+    """
+    bounds = {
+        "time": (time, time_step),
+        "latitude": (latitude, latitude_step),
+        "longitude": (longitude, longitude_step),
+        "depth": (depth, depth_step),
+    }
+
+    real_ranges: Dict[str, Tuple[Any, Any]] = {}
+    if validate and dataset_id is not None:
+        try:
+            real_ranges = _layer_info(dataset_id)["dimensions"]
+        except Exception as exc:  # network/validation is best-effort
+            warnings.warn(
+                f"Could not fetch ranges for '{dataset_id}' to validate constraints: {exc}"
+            )
+
+    constraints: Dict[str, Any] = {}
+    for dim, (value, step) in bounds.items():
+        if value is None:
+            continue
+        lo, hi = value
+        constraints[f"{dim}>="] = lo
+        constraints[f"{dim}<="] = hi
+        constraints[f"{dim}_step"] = step
+
+        if dim in real_ranges:
+            rlo, rhi = real_ranges[dim]
+            # Numeric dimensions only; skip time string comparisons.
+            if dim != "time" and None not in (rlo, rhi):
+                try:
+                    if lo < rlo or hi > rhi:
+                        warnings.warn(
+                            f"Requested {dim} range ({lo}, {hi}) is outside the "
+                            f"dataset range ({rlo}, {rhi}) for '{dataset_id}'."
+                        )
+                except TypeError:
+                    pass
+
+    return constraints
 
 
 @lru_cache(2)
@@ -212,6 +406,7 @@ def _download_layer(
     log: bool = True,
     timestamp: bool = True,
     timeout: int = 120,
+    variables: Optional[Container[str]] = None,
     **httpx_kwargs,
 ) -> None:
     """
@@ -245,7 +440,7 @@ def _download_layer(
 
     # Check for existing layers
     if skip_confirmation is None:
-        skip_confirmation = eval(config["skip_confirmation"])
+        skip_confirmation = _as_bool(config["skip_confirmation"])
     if not skip_confirmation:
         print()
         print(f"Data directory is '{outdir}'.", end="\n\n")
@@ -291,7 +486,7 @@ def _download_layer(
     verbose_print(constraints, verbose)
 
     url = _get_griddap_dataset_url(
-        dataset_id, constraints=constraints, response=response
+        dataset_id, variables=variables, constraints=constraints, response=response
     )
     _download_file_from_url(url, local_path, timeout=timeout, **httpx_kwargs)
     if (verbose or log) and local_path.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["pyo_oracle"]
 
 [project]
 name = "pyo_oracle"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name="Vini Salazar", email="vinicius.salazar@unimelb.edu.au" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,21 +5,51 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = ["pyo_oracle"]
 
+[tool.setuptools.package-data]
+pyo_oracle = ["config.ini", "data/.gitkeep"]
+
 [project]
 name = "pyo_oracle"
-version = "0.2.0"
+version = "1.0.0"
 authors = [
   { name="Vini Salazar", email="vinicius.salazar@unimelb.edu.au" },
 ]
 description = "Python client for the Bio-ORACLE ERDDAP server."
 readme = "README.md"
-requires-python = ">=3.7"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+keywords = ["bio-oracle", "erddap", "oceanography", "marine", "climate", "sdm"]
 classifiers = [
-    "Programming Language :: Python :: 3",
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: GIS",
+    "Topic :: Scientific/Engineering :: Oceanography",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["erddapy",]
+dependencies = [
+    "erddapy>=2.2",
+    "pandas>=2.0",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+xarray = ["xarray>=2023.1.0", "netCDF4>=1.6"]
+docs = ["mkdocs-material>=9.5", "mkdocstrings[python]>=0.24", "mkdocs-jupyter>=0.24"]
+dev = ["pytest>=7.0", "pytest-cov>=4.0", "respx>=0.21", "flake8>=6.0", "ruff>=0.4"]
 
 [project.urls]
 "Homepage" = "https://github.com/bio-oracle/pyo_oracle"
+"Documentation" = "https://bio-oracle.github.io/pyo_oracle/"
+"Bug Tracker" = "https://github.com/bio-oracle/pyo_oracle/issues"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that hit the live Bio-ORACLE ERDDAP server (deselect with -m 'not integration')",
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,6 +35,7 @@ def layer():
     return layer
 
 
+@pytest.mark.integration
 class TestListLayers:
     """Tests for the `pyo.list_layers` function with various filters."""
 
@@ -102,6 +103,7 @@ class TestListLayers:
         assert df1 is df3
 
 
+@pytest.mark.integration
 def test_download_layers(layer, constraints, test_data_dir):
     pyo.download_layers(
         layer,
@@ -112,6 +114,24 @@ def test_download_layers(layer, constraints, test_data_dir):
     )
 
 
+@pytest.mark.integration
+def test_download_layers_variables(layer, constraints, tmp_path):
+    """Downloading with a `variables` subset should produce a file with only that column."""
+    pyo.download_layers(
+        layer,
+        output_directory=tmp_path,
+        response="csv",
+        constraints=constraints,
+        variables=["thetao_mean"],
+        skip_confirmation=True,
+    )
+    files = list(Path(tmp_path).glob(f"{layer}*.csv"))
+    assert len(files) == 1
+    header = files[0].read_text().splitlines()[0]
+    assert "thetao_mean" in header
+    assert "thetao_max" not in header
+
+
 def test_list_local_data(test_data_dir):
     pyo.list_local_data(
         test_data_dir,
@@ -119,6 +139,63 @@ def test_list_local_data(test_data_dir):
     pyo.list_local_data(test_data_dir, verbose=True)
 
 
+@pytest.mark.integration
+class TestInfoLayer:
+    def test_info_layer_structure(self, layer):
+        info = pyo.info_layer(layer, verbose=False)
+        assert info["dataset_id"] == layer
+        assert "latitude" in info["dimensions"]
+        assert "longitude" in info["dimensions"]
+        assert "thetao_mean" in info["variables"]
+        assert info["variables"]["thetao_mean"]["units"] == "degree_C"
+
+    def test_info_layer_prints(self, layer, capsys):
+        pyo.info_layer(layer, verbose=True)
+        out = capsys.readouterr().out
+        assert "Dimensions:" in out
+        assert "Variables:" in out
+
+
+@pytest.mark.integration
+class TestLoadLayer:
+    @pytest.fixture
+    def small_constraints(self, layer):
+        return pyo.build_constraints(
+            layer,
+            latitude=(0, 5),
+            longitude=(0, 5),
+            latitude_step=50,
+            longitude_step=50,
+        )
+
+    def test_load_layer_pandas(self, layer, small_constraints):
+        df = pyo.load_layer(
+            layer, constraints=small_constraints, variables=["thetao_mean"]
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert any("thetao_mean" in c for c in df.columns)
+
+    def test_load_layer_xarray(self, layer, small_constraints):
+        xr = pytest.importorskip("xarray")
+        ds = pyo.load_layer(
+            layer, constraints=small_constraints, variables=["thetao_mean"], fmt="xarray"
+        )
+        assert isinstance(ds, xr.Dataset)
+        assert "thetao_mean" in ds.data_vars
+
+    def test_load_layer_bad_fmt(self, layer):
+        with pytest.raises(ValueError):
+            pyo.load_layer(layer, fmt="bogus")
+
+
+@pytest.mark.integration
+def test_build_constraints_out_of_range_warns(layer):
+    with pytest.warns(UserWarning):
+        pyo.build_constraints(layer, latitude=(-200, 200))
+
+
+@pytest.mark.integration
 def test_manual_erddapy_requests(layer, constraints, test_data_dir):
     e = ERDDAP(server=pyo.config["erddap_server"], protocol="griddap")
     e.dataset_id = layer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,81 @@
+"""Offline unit tests for helpers that do not require network access."""
+
+import pytest
+
+from pyo_oracle.utils import (
+    _as_bool,
+    _ensure_hashable,
+    build_constraints,
+    convert_bytes,
+)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (True, True),
+        (False, False),
+        ("True", True),
+        ("true", True),
+        ("False", False),
+        ("false", False),
+        ("1", True),
+        ("0", False),
+        ("yes", True),
+        ("no", False),
+        (1, True),
+        (0, False),
+        (None, False),
+    ],
+)
+def test_as_bool(value, expected):
+    assert _as_bool(value) is expected
+
+
+def test_convert_bytes():
+    assert convert_bytes(0) == "0.0 bytes"
+    assert convert_bytes(1024) == "1.0 KB"
+    assert convert_bytes(1024 * 1024) == "1.0 MB"
+
+
+def test_ensure_hashable():
+    assert _ensure_hashable(None) is None
+    assert _ensure_hashable("a") == ("a",)
+    # order independence
+    assert _ensure_hashable(["b", "a"]) == ("a", "b")
+    assert _ensure_hashable({"b", "a"}) == ("a", "b")
+
+
+class TestBuildConstraints:
+    def test_full_constraints(self):
+        c = build_constraints(
+            time=("2000-01-01T00:00:00Z", "2010-01-01T00:00:00Z"),
+            latitude=(0, 10),
+            longitude=(0, 10),
+            latitude_step=2,
+            validate=False,
+        )
+        assert c == {
+            "time>=": "2000-01-01T00:00:00Z",
+            "time<=": "2010-01-01T00:00:00Z",
+            "time_step": 1,
+            "latitude>=": 0,
+            "latitude<=": 10,
+            "latitude_step": 2,
+            "longitude>=": 0,
+            "longitude<=": 10,
+            "longitude_step": 1,
+        }
+
+    def test_partial_constraints(self):
+        c = build_constraints(latitude=(0, 5), validate=False)
+        assert set(c) == {"latitude>=", "latitude<=", "latitude_step"}
+
+    def test_empty_constraints(self):
+        assert build_constraints(validate=False) == {}
+
+    def test_depth_included(self):
+        c = build_constraints(depth=(0, 100), depth_step=5, validate=False)
+        assert c["depth>="] == 0
+        assert c["depth<="] == 100
+        assert c["depth_step"] == 5


### PR DESCRIPTION
## Summary

Brings `pyo_oracle` up to date and to **feature parity with [`biooracler`](https://github.com/bio-oracle/biooracler)**, plus new functionality. Ships as **v1.0.0**.

### New API
- **`info_layer(dataset_id)`** — dimension ranges + variables/units (biooracler parity; was missing).
- **`load_layer(...)`** — load a layer into memory as `pandas.DataFrame` or `xarray.Dataset`.
- **`build_constraints(...)`** — build griddap constraints from friendly `(min, max)` bounds + strides, validated against the dataset's real ranges.
- **`download_layers(variables=...)`** — download a subset of variables (was unwired).

### Dependencies & packaging
- Declared `erddapy>=2.2`, `pandas>=2.0`, `httpx>=0.27`; Python floor `>=3.9`.
- Extras: `[xarray]`, `[docs]`, `[dev]`. Version bumped to `1.0.0`.

### Internals / hardening
- Single shared `_build_griddap_server` path for downloads, in-memory loads, and metadata.
- Replaced unsafe `eval()` of `skip_confirmation` with `_as_bool`.
- Guarded erddapy private `_constraints_original` usage (verified vs erddapy 3.2.x).

### Docs
- MkDocs Material site (quickstart, 3 tutorials, mkdocstrings API ref) + GitHub Pages deploy workflow.

### Testing & CI
- `tests/test_utils.py` offline unit tests; `integration` marker separates live-server tests.
- CI: Python 3.9–3.13 matrix, ruff lint, modern action versions, split integration job.
- `pypi-publish.yml` runs offline tests only.

### Verification
- `pytest` full suite: **43 passed** (offline `-m "not integration"`: 25 passed).
- `ruff check` clean; `mkdocs build --strict` passes; `python -m build` + `twine check` pass.

> PyPI publish is not triggered by this PR — it fires on a `v1.0.0` tag push after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)