### PR TITLE
feat: public get_layer_url() (closes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - Unreleased
+
+### Added
+
+- **`get_layer_url(dataset_id, ...)`** — build the ERDDAP download URL for a
+  layer (with constraints, variable subset, and response format) without
+  downloading it, for sharing or fetching elsewhere. Resolves #1.
+
 ## [1.0.0] - 2026-06-02
 
 First stable release. Modernizes dependencies, reaches feature parity with the

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,8 @@ namespace, e.g. `pyo_oracle.list_layers(...)`.
 
 ::: pyo_oracle.download_layers
 
+::: pyo_oracle.get_layer_url
+
 ::: pyo_oracle.list_local_data
 
 ## Configuration

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -73,6 +73,18 @@ pyo.download_layers(
 )
 ```
 
+Prefer just the request URL (to share, email, or fetch elsewhere)? Use
+[`get_layer_url`][pyo_oracle.get_layer_url]:
+
+```python
+url = pyo.get_layer_url(
+    "thetao_baseline_2000_2019_depthsurf",
+    constraints=constraints,
+    variables=["thetao_mean"],
+    response="nc",
+)
+```
+
 ## 5. Manage local data
 
 ```python

--- a/pyo_oracle/__init__.py
+++ b/pyo_oracle/__init__.py
@@ -1,6 +1,7 @@
 from .main import (
     build_constraints,
     download_layers,
+    get_layer_url,
     info_layer,
     list_layers,
     list_local_data,
@@ -23,6 +24,7 @@ __all__ = [
     "info_layer",
     "load_layer",
     "build_constraints",
+    "get_layer_url",
     "config",
     "create_config",
     "get_config_path",

--- a/pyo_oracle/main.py
+++ b/pyo_oracle/main.py
@@ -27,6 +27,7 @@ from pyo_oracle.utils import (
     _build_griddap_server,
     _download_layer,
     _ensure_hashable,
+    _get_griddap_dataset_url,
     _layer_dataframe,
     _layer_info,
     _validate_argument,
@@ -43,6 +44,7 @@ __all__ = [
     "info_layer",
     "load_layer",
     "build_constraints",
+    "get_layer_url",
 ]
 
 # Literal typing for type checking and validation (using _validate_argument)
@@ -454,3 +456,45 @@ def load_layer(
             "Loading layers as xarray requires the optional dependencies. "
             "Install them with: pip install pyo_oracle[xarray]"
         ) from exc
+
+
+def get_layer_url(
+    dataset_id: str,
+    constraints: Optional[Dict[str, Any]] = None,
+    variables: Optional[Iterable[str]] = None,
+    response: str = "nc",
+    verbose: bool = False,
+) -> str:
+    """
+    Builds the ERDDAP download URL for a layer without downloading it.
+
+    Useful for sharing a request (e.g. by email), inspecting it, or fetching it
+    with another tool. The URL encodes the dataset, the selected variables, the
+    constraints, and the response format.
+
+    Args:
+        dataset_id (str): The dataset ID.
+        constraints (dict, optional): Constraints to apply. See ``build_constraints``.
+        variables (list, optional): Subset of variables to include. If None, all are included.
+        response (str): Response/file format, e.g. "nc" (default), "csv", "geotif".
+            Note that some formats such as "geotif" require selecting a single variable.
+        verbose (bool): If True, print selection details.
+
+    Returns:
+        str: The fully-formed ERDDAP griddap download URL.
+
+    Example:
+        url = get_layer_url(
+            "thetao_baseline_2000_2019_depthsurf",
+            constraints=constraints,
+            variables=["thetao_mean"],
+            response="nc",
+        )
+    """
+    return _get_griddap_dataset_url(
+        dataset_id,
+        variables=variables,
+        constraints=constraints,
+        response=response,
+        verbose=verbose,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ pyo_oracle = ["config.ini", "data/.gitkeep"]
 
 [project]
 name = "pyo_oracle"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
   { name="Vini Salazar", email="vinicius.salazar@unimelb.edu.au" },
 ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -196,6 +196,15 @@ def test_build_constraints_out_of_range_warns(layer):
 
 
 @pytest.mark.integration
+def test_get_layer_url(layer, constraints):
+    url = pyo.get_layer_url(layer, constraints=constraints, variables=["thetao_mean"])
+    assert url.startswith("http")
+    assert f"griddap/{layer}" in url
+    assert "thetao_mean" in url
+    assert "thetao_max" not in url
+
+
+@pytest.mark.integration
 def test_manual_erddapy_requests(layer, constraints, test_data_dir):
     e = ERDDAP(server=pyo.config["erddap_server"], protocol="griddap")
     e.dataset_id = layer


### PR DESCRIPTION
## Summary

Resolves the last open feature issue, **#1** (*Add function that converts requests to URLs*).

Adds a public **`get_layer_url()`** that builds the ERDDAP griddap download URL for a layer — with constraints, an optional variable subset, and a response format — **without downloading**. Useful for sharing/emailing a request or fetching it with another tool. It's a thin wrapper over the existing internal `_get_griddap_dataset_url`.

```python
pyo.get_layer_url(
    "thetao_baseline_2000_2019_depthsurf",
    constraints=c, variables=["thetao_mean"], response="nc",
)
# -> https://erddap.bio-oracle.org/erddap/griddap/thetao_baseline_2000_2019_depthsurf.nc?thetao_mean[...]
```

## Changes
- `get_layer_url()` in `main.py`, exported from the package namespace.
- Integration test asserting the URL targets the dataset and respects the variable subset.
- API reference + quickstart docs.
- Version bump to **1.1.0**; CHANGELOG entry.

## Verification
- `pytest`: **44 passed**; `ruff check` clean; `mkdocs build --strict` passes.

## Related issues
- #2 (load data into Python) and #5 (subset variables) were already delivered in v1.0.0 via `load_layer()` and `variables=`. Left open per maintainer preference.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)