### PR TITLE
test: expand suite to ~99% coverage + enforce gate

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,7 +37,8 @@ jobs:
     - name: Test with coverage (unit tests only)
       run: |
         python -m pytest -m "not integration" \
-          --cov=pyo_oracle --cov-report=html --cov-report=term-missing tests/
+          --cov=pyo_oracle --cov-report=html --cov-report=term-missing \
+          --cov-fail-under=90 tests/
     - name: Upload coverage report
       if: matrix.python-version == '3.12'
       uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - Unreleased
+
+### Tests
+
+- Greatly expanded the test suite with offline unit tests that mock the network
+  boundary (`_build_griddap_server`, `_layer_info`, `_download_file_from_url`,
+  `_layer_dataframe`). Total coverage rose from 85% to ~99%, and the
+  network-free `list_layers` filtering, config error paths, `build_constraints`
+  validation, and download flows are now covered without hitting the server.
+- CI enforces a minimum coverage of 90% on the offline test run.
+
 ## [1.0.0] - 2026-06-02
 
 First stable release. Modernizes dependencies, reaches feature parity with the

--- a/pyo_oracle/main.py
+++ b/pyo_oracle/main.py
@@ -270,7 +270,7 @@ def _list_layers(
             for col in ("datasetID", "title", "long_name", "standard_name")
             if col in _dataframe.columns
         ]
-        if not searchable_columns:
+        if not searchable_columns:  # pragma: no cover - defensive; server always returns datasetID
             searchable_columns = ["datasetID"]
 
         mask = pd.Series(False, index=_dataframe.index)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,3 +66,35 @@ def test_print_config_values_outputs_defaults(temp_config_path, capsys):
     assert str(temp_config_path) in output
     for key in ("data_directory", "erddap_server", "skip_confirmation"):
         assert key in output
+
+
+def test_print_config_values_creates_missing_file(temp_config_path, capsys):
+    # File does not exist yet -> the function should create it first.
+    assert not temp_config_path.exists()
+
+    config_module.print_config_values()
+
+    assert temp_config_path.exists()
+    assert "Config file doesn't exist, creating it." in capsys.readouterr().out
+
+
+def test_get_default_config_creates_missing_file(temp_config_path):
+    assert not temp_config_path.exists()
+
+    parser = config_module._get_default_config()
+
+    assert temp_config_path.exists()
+    assert parser["DEFAULT"]["erddap_server"] == config_module._default_config["erddap_server"]
+
+
+def test_get_default_config_falls_back_on_error(temp_config_path, monkeypatch, capsys):
+    # Creation fails -> fall back to in-memory defaults without raising.
+    def boom(*_args, **_kwargs):
+        raise OSError("cannot write")
+
+    monkeypatch.setattr(config_module, "create_config", boom)
+
+    parser = config_module._get_default_config()
+
+    assert parser["DEFAULT"]["erddap_server"] == config_module._default_config["erddap_server"]
+    assert "could not load or create" in capsys.readouterr().out

--- a/tests/test_main_unit.py
+++ b/tests/test_main_unit.py
@@ -1,0 +1,215 @@
+"""Offline unit tests for the public functions in ``pyo_oracle.main``.
+
+Network-touching helpers are mocked so these run without hitting the server.
+"""
+
+import pandas as pd
+import pytest
+
+import pyo_oracle as pyo
+from pyo_oracle import main
+
+
+# --------------------------------------------------------------------------- #
+# download_layers (delegates to _download_layer, mocked)
+# --------------------------------------------------------------------------- #
+class TestDownloadLayers:
+    def test_skip_confirmation_passes_through(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            main, "_download_layer", lambda dataset_id, *a, **k: calls.append(dataset_id)
+        )
+        pyo.download_layers("thetao_test", skip_confirmation=True)
+        assert calls == ["thetao_test"]
+
+    def test_no_constraints_declined_aborts(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(main, "_download_layer", lambda *a, **k: calls.append(1))
+        # Force the "no constraints" confirmation and decline it.
+        monkeypatch.setattr(main, "confirm", lambda *a, **k: False)
+        pyo.download_layers("thetao_test", skip_confirmation=False, constraints=None)
+        assert calls == []
+
+    def test_no_constraints_accepted_proceeds(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(main, "_download_layer", lambda *a, **k: calls.append(1))
+        monkeypatch.setattr(main, "confirm", lambda *a, **k: True)
+        pyo.download_layers("thetao_test", skip_confirmation=False, constraints=None)
+        assert calls == [1]
+
+    def test_uppercase_id_is_lowercased(self, monkeypatch, capsys):
+        seen = []
+        monkeypatch.setattr(
+            main, "_download_layer", lambda dataset_id, *a, **k: seen.append(dataset_id)
+        )
+        pyo.download_layers("Thetao_TEST", skip_confirmation=True)
+        assert seen == ["thetao_test"]
+        assert "lowercase" in capsys.readouterr().out
+
+    def test_skip_confirmation_none_reads_config(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(main, "_download_layer", lambda *a, **k: calls.append(1))
+        monkeypatch.setitem(main.config, "skip_confirmation", "True")
+        pyo.download_layers("thetao_test", skip_confirmation=None, constraints=None)
+        assert calls == [1]
+
+
+# --------------------------------------------------------------------------- #
+# info_layer (uses _layer_info, mocked)
+# --------------------------------------------------------------------------- #
+_FAKE_INFO = {
+    "dataset_id": "thetao_test",
+    "dimensions": {"latitude": (-90, 90), "longitude": (-180, 180)},
+    "variables": {
+        "thetao_mean": {"units": "degree_C", "long_name": "Average OceanTemperature"},
+        "thetao_no_meta": {"units": None, "long_name": None},
+    },
+    "griddap_constraints": {},
+}
+
+
+class TestInfoLayer:
+    def test_returns_info(self, monkeypatch):
+        monkeypatch.setattr(main, "_layer_info", lambda _id: _FAKE_INFO)
+        info = pyo.info_layer("thetao_test", verbose=False)
+        assert info is _FAKE_INFO
+
+    def test_verbose_prints(self, monkeypatch, capsys):
+        monkeypatch.setattr(main, "_layer_info", lambda _id: _FAKE_INFO)
+        pyo.info_layer("thetao_test", verbose=True)
+        out = capsys.readouterr().out
+        assert "Dimensions:" in out
+        assert "latitude: -90 to 90" in out
+        assert "Average OceanTemperature [degree_C]" in out
+        # Variable without metadata falls back to its name and no units.
+        assert "thetao_no_meta" in out
+
+
+# --------------------------------------------------------------------------- #
+# load_layer (uses _build_griddap_server, mocked)
+# --------------------------------------------------------------------------- #
+class _FakeServer:
+    def to_pandas(self):
+        return pd.DataFrame({"thetao_mean": [1.0, 2.0]})
+
+    def to_xarray(self):
+        return {"sentinel": "xarray-dataset"}
+
+
+class TestLoadLayer:
+    def test_pandas(self, monkeypatch):
+        monkeypatch.setattr(main, "_build_griddap_server", lambda *a, **k: _FakeServer())
+        df = pyo.load_layer("thetao_test")
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == ["thetao_mean"]
+
+    def test_xarray(self, monkeypatch):
+        monkeypatch.setattr(main, "_build_griddap_server", lambda *a, **k: _FakeServer())
+        ds = pyo.load_layer("thetao_test", fmt="xarray")
+        assert ds == {"sentinel": "xarray-dataset"}
+
+    def test_bad_fmt(self):
+        with pytest.raises(ValueError, match="Unsupported fmt"):
+            pyo.load_layer("thetao_test", fmt="bogus")
+
+
+# --------------------------------------------------------------------------- #
+# list_local_data
+# --------------------------------------------------------------------------- #
+_FAKE_DATASETS = pd.DataFrame(
+    {
+        "datasetID": [
+            "thetao_baseline_2000_2019_depthsurf",
+            "thetao_ssp119_2020_2100_depthmean",
+            "po4_baseline_2000_2018_depthsurf",
+            "po4_ssp585_2020_2100_depthmax",
+        ],
+        "title": [
+            "Sea water potential temperature baseline",
+            "Sea water potential temperature ssp119",
+            "Phosphate baseline",
+            "Phosphate ssp585",
+        ],
+        "long_name": ["temperature", "temperature", "phosphate", "phosphate"],
+        "standard_name": ["sea_water_temp", "sea_water_temp", "po4", "po4"],
+    }
+)
+
+
+class TestListLayersOffline:
+    """Exercise the filtering logic of list_layers without the network."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_datasets(self, monkeypatch):
+        main._list_layers.cache_clear()
+        monkeypatch.setattr(main, "_layer_dataframe", lambda *a, **k: _FAKE_DATASETS.copy())
+        yield
+        main._list_layers.cache_clear()
+
+    def test_all(self):
+        df = pyo.list_layers()
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 4
+
+    def test_filter_variables(self):
+        df = pyo.list_layers(variables="po4")
+        assert set(df["datasetID"].str.split("_").str[0]) == {"po4"}
+
+    def test_filter_ssp(self):
+        df = pyo.list_layers(ssp="ssp119")
+        assert df["datasetID"].str.contains("ssp119").all()
+        assert len(df) == 1
+
+    def test_filter_time_period_present(self):
+        df = pyo.list_layers(time_period="present")
+        assert (df["datasetID"].str.split("_").str[2] == "2000").all()
+
+    def test_filter_time_period_future(self):
+        df = pyo.list_layers(time_period="future")
+        assert (df["datasetID"].str.split("_").str[2] == "2020").all()
+
+    def test_filter_depth(self):
+        df = pyo.list_layers(depth="surf")
+        assert df["datasetID"].str.contains("depthsurf").all()
+
+    def test_search(self):
+        df = pyo.list_layers(search="phosphate")
+        assert len(df) == 2
+
+    def test_simplify(self):
+        df = pyo.list_layers(simplify=True)
+        assert list(df.columns) == ["datasetID", "title"]
+
+    def test_return_list(self):
+        result = pyo.list_layers(variables="po4", dataframe=False)
+        assert isinstance(result, list)
+        assert all(isinstance(x, str) for x in result)
+
+    def test_invalid_variable_warns(self, capsys):
+        pyo.list_layers(variables="not_a_var")
+        assert "not a valid variables" in capsys.readouterr().out
+
+
+class TestListLocalData:
+    def test_empty_directory(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setitem(main.config, "data_directory", str(tmp_path))
+        pyo.list_local_data()
+        assert "does not contain any data" in capsys.readouterr().out
+
+    def test_with_files_verbose(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setitem(main.config, "data_directory", str(tmp_path))
+        (tmp_path / "layer.nc").write_text("data")
+        (tmp_path / "layer.log").write_text("log")
+        pyo.list_local_data(verbose=True)
+        out = capsys.readouterr().out
+        assert "layer.nc" in out
+        assert "Size of data directory" in out
+
+    def test_with_files_non_verbose_hides_logs(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setitem(main.config, "data_directory", str(tmp_path))
+        (tmp_path / "layer.nc").write_text("data")
+        (tmp_path / "layer.log").write_text("log")
+        pyo.list_local_data(verbose=False)
+        out = capsys.readouterr().out
+        assert "layer.nc" in out
+        assert "layer.log" not in out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,33 @@
-"""Offline unit tests for helpers that do not require network access."""
+"""Offline unit tests for helpers that do not require network access.
 
+Functions that normally reach the Bio-ORACLE server are exercised here by
+mocking the network boundary (``_build_griddap_server``, ``_get_griddap_dataset_url``,
+``_download_file_from_url``, ``_layer_info``) so the suite stays fast and
+deterministic.
+"""
+
+from pathlib import Path
+
+import httpx
 import pytest
 
+from pyo_oracle import utils
 from pyo_oracle.utils import (
     _as_bool,
+    _download_file_from_url,
+    _download_layer,
     _ensure_hashable,
+    _layer_info,
+    _validate_argument,
     build_constraints,
+    confirm,
     convert_bytes,
 )
 
 
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(
     "value, expected",
     [
@@ -25,6 +43,7 @@ from pyo_oracle.utils import (
         ("no", False),
         (1, True),
         (0, False),
+        (1.0, True),
         (None, False),
     ],
 )
@@ -36,16 +55,59 @@ def test_convert_bytes():
     assert convert_bytes(0) == "0.0 bytes"
     assert convert_bytes(1024) == "1.0 KB"
     assert convert_bytes(1024 * 1024) == "1.0 MB"
+    assert convert_bytes(1024 ** 4) == "1.0 TB"
 
 
 def test_ensure_hashable():
     assert _ensure_hashable(None) is None
     assert _ensure_hashable("a") == ("a",)
-    # order independence
     assert _ensure_hashable(["b", "a"]) == ("a", "b")
     assert _ensure_hashable({"b", "a"}) == ("a", "b")
 
 
+def test_ensure_hashable_rejects_unhashable_input():
+    with pytest.raises(ValueError):
+        _ensure_hashable(123)
+
+
+# --------------------------------------------------------------------------- #
+# _validate_argument
+# --------------------------------------------------------------------------- #
+class TestValidateArgument:
+    def test_none_is_ok(self, capsys):
+        _validate_argument("variables", None, {"thetao"})
+        assert capsys.readouterr().out == ""
+
+    def test_valid_str(self, capsys):
+        _validate_argument("variables", "thetao", {"thetao"})
+        assert capsys.readouterr().out == ""
+
+    def test_invalid_str_prints(self, capsys):
+        _validate_argument("variables", "bogus", {"thetao"})
+        assert "not a valid variables" in capsys.readouterr().out
+
+    def test_invalid_in_iterable_prints(self, capsys):
+        _validate_argument("variables", ["thetao", "bogus"], {"thetao"})
+        assert "bogus" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# confirm
+# --------------------------------------------------------------------------- #
+class TestConfirm:
+    def test_yes(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda *_: "y")
+        assert confirm("proceed?") is True
+
+    def test_no(self, monkeypatch, capsys):
+        monkeypatch.setattr("builtins.input", lambda *_: "n")
+        assert confirm("proceed?") is False
+        assert "cancelled" in capsys.readouterr().out.lower()
+
+
+# --------------------------------------------------------------------------- #
+# build_constraints
+# --------------------------------------------------------------------------- #
 class TestBuildConstraints:
     def test_full_constraints(self):
         c = build_constraints(
@@ -79,3 +141,189 @@ class TestBuildConstraints:
         assert c["depth>="] == 0
         assert c["depth<="] == 100
         assert c["depth_step"] == 5
+
+    def test_validate_within_range_no_warning(self, monkeypatch, recwarn):
+        monkeypatch.setattr(
+            utils,
+            "_layer_info",
+            lambda _id: {"dimensions": {"latitude": (-90, 90)}},
+        )
+        build_constraints("fake", latitude=(0, 10))
+        assert len(recwarn) == 0
+
+    def test_validate_out_of_range_warns(self, monkeypatch):
+        monkeypatch.setattr(
+            utils,
+            "_layer_info",
+            lambda _id: {"dimensions": {"latitude": (-90, 90)}},
+        )
+        with pytest.warns(UserWarning, match="outside the dataset range"):
+            build_constraints("fake", latitude=(-200, 10))
+
+    def test_validate_lookup_failure_warns(self, monkeypatch):
+        def boom(_id):
+            raise RuntimeError("offline")
+
+        monkeypatch.setattr(utils, "_layer_info", boom)
+        with pytest.warns(UserWarning, match="Could not fetch ranges"):
+            build_constraints("fake", latitude=(0, 10))
+
+    def test_validate_incomparable_bounds_ignored(self, monkeypatch):
+        # Non-numeric bounds against a numeric range hit the TypeError guard
+        # and are silently skipped (no warning, constraint still emitted).
+        monkeypatch.setattr(
+            utils,
+            "_layer_info",
+            lambda _id: {"dimensions": {"latitude": (-90, 90)}},
+        )
+        c = build_constraints("fake", latitude=("a", "b"))
+        assert c["latitude>="] == "a"
+
+
+def test_get_griddap_dataset_url(monkeypatch):
+    class _UrlServer:
+        def get_download_url(self, response="nc"):
+            return f"https://x/griddap/ds.{response}"
+
+    monkeypatch.setattr(utils, "_build_griddap_server", lambda *a, **k: _UrlServer())
+    url = utils._get_griddap_dataset_url("ds", response="csv")
+    assert url == "https://x/griddap/ds.csv"
+
+
+# --------------------------------------------------------------------------- #
+# _layer_info (network boundary mocked)
+# --------------------------------------------------------------------------- #
+class _FakeServer:
+    def __init__(self, info_csv=None, raise_info=False):
+        self.constraints = {
+            "latitude>=": -90,
+            "latitude<=": 90,
+            "longitude>=": -180,
+            "longitude<=": 180,
+        }
+        self.variables = ["thetao_mean"]
+        self._info_csv = info_csv
+        self._raise_info = raise_info
+
+    def get_info_url(self, response="csv"):
+        if self._raise_info:
+            raise RuntimeError("no network")
+        return str(self._info_csv)
+
+
+def _write_info_csv(path: Path) -> Path:
+    path.write_text(
+        "Row Type,Variable Name,Attribute Name,Data Type,Value\n"
+        "attribute,thetao_mean,units,String,degree_C\n"
+        "attribute,thetao_mean,long_name,String,Average OceanTemperature\n"
+    )
+    return path
+
+
+class TestLayerInfo:
+    def test_success(self, monkeypatch, tmp_path):
+        _layer_info.cache_clear()
+        csv = _write_info_csv(tmp_path / "info.csv")
+        monkeypatch.setattr(
+            utils, "_build_griddap_server", lambda _id: _FakeServer(info_csv=csv)
+        )
+        info = _layer_info("ds-success")
+        assert info["dataset_id"] == "ds-success"
+        assert info["dimensions"]["latitude"] == (-90, 90)
+        assert info["variables"]["thetao_mean"]["units"] == "degree_C"
+        assert info["variables"]["thetao_mean"]["long_name"] == "Average OceanTemperature"
+
+    def test_metadata_fallback(self, monkeypatch):
+        _layer_info.cache_clear()
+        monkeypatch.setattr(
+            utils, "_build_griddap_server", lambda _id: _FakeServer(raise_info=True)
+        )
+        info = _layer_info("ds-fallback")
+        # Falls back to bare variable names when metadata can't be read.
+        assert info["variables"]["thetao_mean"] == {"units": None, "long_name": None}
+
+
+# --------------------------------------------------------------------------- #
+# _download_file_from_url (httpx mocked with respx)
+# --------------------------------------------------------------------------- #
+import respx  # noqa: E402
+
+
+@respx.mock
+def test_download_file_from_url(tmp_path):
+    url = "https://example.org/data.nc"
+    respx.get(url).mock(return_value=httpx.Response(200, content=b"hello-bytes"))
+    dest = tmp_path / "out.nc"
+    result = _download_file_from_url(url, dest)
+    assert result == dest
+    assert dest.read_bytes() == b"hello-bytes"
+
+
+# --------------------------------------------------------------------------- #
+# _download_layer (network + url building mocked)
+# --------------------------------------------------------------------------- #
+class TestDownloadLayer:
+    def test_writes_file_when_skipping_confirmation(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            utils, "_get_griddap_dataset_url", lambda *a, **k: "https://x/y.nc"
+        )
+
+        def fake_dl(url, local_path, **kwargs):
+            Path(local_path).write_text("data")
+            return local_path
+
+        monkeypatch.setattr(utils, "_download_file_from_url", fake_dl)
+
+        _download_layer(
+            "thetao_test",
+            output_directory=tmp_path,
+            response="nc",
+            skip_confirmation=True,
+            timestamp=False,
+        )
+        assert (tmp_path / "thetao_test.nc").exists()
+
+    def test_cancel_when_existing_layer_and_user_declines(self, monkeypatch, tmp_path):
+        # Pre-existing layer with the same prefix triggers the confirmation block.
+        (tmp_path / "thetao_test.nc").write_text("old")
+
+        called = {"dl": False}
+
+        def fake_dl(url, local_path, **kwargs):
+            called["dl"] = True
+            return local_path
+
+        monkeypatch.setattr(utils, "_download_file_from_url", fake_dl)
+        monkeypatch.setattr(
+            utils, "_get_griddap_dataset_url", lambda *a, **k: "https://x/y.nc"
+        )
+        monkeypatch.setattr(utils, "confirm", lambda *a, **k: False)
+
+        _download_layer(
+            "thetao_test",
+            output_directory=tmp_path,
+            skip_confirmation=False,
+            timestamp=False,
+        )
+        assert called["dl"] is False
+
+    def test_skip_confirmation_none_reads_config(self, monkeypatch, tmp_path):
+        # skip_confirmation=None -> resolved from config via _as_bool.
+        monkeypatch.setitem(utils.config, "skip_confirmation", "True")
+        monkeypatch.setattr(
+            utils, "_get_griddap_dataset_url", lambda *a, **k: "https://x/y.nc"
+        )
+
+        def fake_dl(url, local_path, **kwargs):
+            Path(local_path).write_text("data")
+            return local_path
+
+        monkeypatch.setattr(utils, "_download_file_from_url", fake_dl)
+
+        _download_layer(
+            "thetao_test",
+            output_directory=tmp_path,
+            skip_confirmation=None,
+            timestamp=False,
+        )
+        assert (tmp_path / "thetao_test.nc").exists()


### PR DESCRIPTION
## Summary

Next v1.1.0 work item: **improve test-suite coverage.** Adds offline unit tests that mock the network boundary, so most logic is now verified without hitting the live Bio-ORACLE server.

**Coverage: 85% → ~99%** (full suite). The network-free `build` CI job alone covers **93%** and now enforces `--cov-fail-under=90`.

| Module | Before | After (full suite) |
|--------|--------|--------------------|
| `_config.py` | 80% | 100% |
| `main.py` | 90% | 99%* |
| `utils.py` | 83% | 100% |
| **Total** | **85%** | **99%** |

\* one defensive, unreachable `searchable_columns` fallback marked `# pragma: no cover`.

## What's covered now (offline)
- **`list_layers`** filtering (variables/ssp/time_period/depth/search/simplify/list) via a mocked `_layer_dataframe`.
- **`download_layers`** branches: skip-confirmation, config-driven skip, no-constraints decline/accept, lowercase conversion.
- **`info_layer`**, **`load_layer`** (pandas/xarray/bad-fmt), **`list_local_data`** (empty/files/verbose).
- **`build_constraints`** validation: in-range, out-of-range warning, lookup failure, incomparable bounds.
- **`_layer_info`** success + metadata fallback; **`_download_file_from_url`** (respx); **`_download_layer`** (skip/cancel/config); **`_get_griddap_dataset_url`**.
- **`_config`** error/creation paths.

Live-server behaviour stays covered by the `integration`-marked tests.

## Verification
- `pytest`: **88 passed** (full); offline `-m "not integration"`: 70 passed at 93%.
- `ruff check` clean.

Targets `dev` for the upcoming v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)